### PR TITLE
feat(hikarinagi): resolve galgame ids for lunabox and reina push

### DIFF
--- a/apps/backend/prisma/game.prisma
+++ b/apps/backend/prisma/game.prisma
@@ -5,6 +5,7 @@ model Game {
   id           Int         @id @default(autoincrement())
   v_id         String?
   b_id         String?
+  h_id         Int?        @unique
   title_jp     String      @default("") @db.VarChar(255)
   title_zh     String      @default("") @db.VarChar(255)
   title_en     String      @default("") @db.VarChar(255)

--- a/apps/backend/prisma/migrations/20260805090119_add_h_id/migration.sql
+++ b/apps/backend/prisma/migrations/20260805090119_add_h_id/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[h_id]` on the table `games` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "game_developers" ALTER COLUMN "extra_info" SET DEFAULT '[]'::jsonb;
+
+-- AlterTable
+ALTER TABLE "games" ADD COLUMN     "h_id" INTEGER,
+ALTER COLUMN "extra_info" SET DEFAULT '[]'::jsonb,
+ALTER COLUMN "staffs" SET DEFAULT '[]'::jsonb;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "games_h_id_key" ON "games"("h_id");

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -46,6 +46,7 @@ import { WalkthroughModule } from './modules/walkthrough/walkthrough.module'
 import { SponsorModule } from './modules/sponsor/sponsor.module'
 import { AdModule } from './modules/ad/ad.module'
 import { PartnerModule } from './modules/partner/partner.module'
+import { HikarinagiModule } from './modules/hikarinagi/hikarinagi.module'
 
 @Module({
   imports: [
@@ -124,6 +125,7 @@ import { PartnerModule } from './modules/partner/partner.module'
     SponsorModule,
     AdModule,
     PartnerModule,
+    HikarinagiModule,
   ],
   controllers: [],
   providers: [

--- a/apps/backend/src/common/config/configs/app.config.ts
+++ b/apps/backend/src/common/config/configs/app.config.ts
@@ -139,6 +139,10 @@ export default (): AppConfig => ({
     secret: withDefault('PARTNER_API_SECRET', ''),
   },
 
+  hikarinagi: {
+    base_url: withDefault('HIKARINAGI_INTERNAL_BASE_URL', ''),
+  },
+
   tasks: {
     image_upload: {
       enabled: withDefault('TASKS_IMAGE_UPLOAD_ENABLED', true),

--- a/apps/backend/src/common/config/interfaces/app.interface.ts
+++ b/apps/backend/src/common/config/interfaces/app.interface.ts
@@ -98,6 +98,9 @@ export interface AppConfig {
   partner: {
     secret: string
   }
+  hikarinagi: {
+    base_url: string
+  }
   tasks: {
     image_upload: {
       enabled: boolean

--- a/apps/backend/src/modules/game/game.module.ts
+++ b/apps/backend/src/modules/game/game.module.ts
@@ -13,6 +13,7 @@ import { GameHotScoreCalcTask } from './tasks/game-hot-score-calc.task'
 import { GameDownloadSourceController } from './controllers/game-download-source.controller'
 import { HttpModule } from '@nestjs/axios'
 import { BangumiModule } from '../bangumi/bangumi.module'
+import { HikarinagiModule } from '../hikarinagi/hikarinagi.module'
 import { GameScoreService } from './services/game-score.service'
 import { GameScoreController } from './controllers/game-score.controller'
 import { GameDownloadResourceReportService } from './services/game-download-resource-report.service'
@@ -29,7 +30,7 @@ import { GameFieldSyncService } from './services/game-field-sync.service'
     GameDownloadSourceController,
     GameScoreController,
   ],
-  imports: [B2Module, HttpModule, BangumiModule],
+  imports: [B2Module, HttpModule, BangumiModule, HikarinagiModule],
   providers: [
     GameDataFetcherService,
     GameService,

--- a/apps/backend/src/modules/game/services/game.service.spec.ts
+++ b/apps/backend/src/modules/game/services/game.service.spec.ts
@@ -21,10 +21,15 @@ describe('GameService', () => {
       zcard: jest.fn(),
     }
 
+    const hikarinagiMappingService = {
+      resolveByBangumiId: jest.fn().mockResolvedValue(null),
+    }
+
     return {
       prisma,
       cacheService,
-      service: new GameService(prisma as any, cacheService as any),
+      hikarinagiMappingService,
+      service: new GameService(prisma as any, cacheService as any, hikarinagiMappingService as any),
     }
   }
 
@@ -320,5 +325,45 @@ describe('GameService', () => {
     )
 
     mathRandomSpy.mockRestore()
+  })
+
+  it('getHeader returns the stored h_id without calling hikarinagi', async () => {
+    const { service, prisma, hikarinagiMappingService } = createService()
+
+    prisma.game.findUnique
+      .mockResolvedValueOnce({ nsfw: false, covers: [{ sexual: 0 }] })
+      .mockResolvedValueOnce({ id: 1, b_id: '123456', h_id: 8001 })
+
+    await expect(service.getHeader(1, UserContentLimit.SHOW_WITH_SPOILER)).resolves.toEqual(
+      expect.objectContaining({ h_id: 8001 }),
+    )
+    expect(hikarinagiMappingService.resolveByBangumiId).not.toHaveBeenCalled()
+  })
+
+  it('getHeader resolves h_id from hikarinagi when it is not stored yet', async () => {
+    const { service, prisma, hikarinagiMappingService } = createService()
+    hikarinagiMappingService.resolveByBangumiId.mockResolvedValue(8002)
+
+    prisma.game.findUnique
+      .mockResolvedValueOnce({ nsfw: false, covers: [{ sexual: 0 }] })
+      .mockResolvedValueOnce({ id: 1, b_id: '123456', h_id: null })
+
+    await expect(service.getHeader(1, UserContentLimit.SHOW_WITH_SPOILER)).resolves.toEqual(
+      expect.objectContaining({ h_id: 8002 }),
+    )
+    expect(hikarinagiMappingService.resolveByBangumiId).toHaveBeenCalledWith(1, '123456')
+  })
+
+  it('getHeader skips the lookup when the game has no b_id to match on', async () => {
+    const { service, prisma, hikarinagiMappingService } = createService()
+
+    prisma.game.findUnique
+      .mockResolvedValueOnce({ nsfw: false, covers: [{ sexual: 0 }] })
+      .mockResolvedValueOnce({ id: 1, b_id: null, h_id: null })
+
+    await expect(service.getHeader(1, UserContentLimit.SHOW_WITH_SPOILER)).resolves.toEqual(
+      expect.objectContaining({ h_id: null }),
+    )
+    expect(hikarinagiMappingService.resolveByBangumiId).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/modules/game/services/game.service.ts
+++ b/apps/backend/src/modules/game/services/game.service.ts
@@ -13,12 +13,14 @@ import { applyDate } from '../helpers/date-filters'
 import { CacheService } from '../../cache/services/cache.service'
 import { RECENT_UPDATE_KEY, RECENT_UPDATE_TTL_MS } from '../constants/recent-update.constant'
 import { RequestWithUser } from '../../../shared/interfaces/auth/request-with-user.interface'
+import { HikarinagiMappingService } from '../../hikarinagi/services/hikarinagi-mapping.service'
 
 @Injectable()
 export class GameService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly cacheService: CacheService,
+    private readonly hikarinagiMappingService: HikarinagiMappingService,
   ) {}
   async getById(id: number, content_limit?: number): Promise<GetGameResDto> {
     await this.handleNotFoundAndContentLimit(id, content_limit)
@@ -126,6 +128,7 @@ export class GameService {
     const select: Prisma.GameSelect = {
       v_id: true,
       b_id: true,
+      h_id: true,
       id: true,
       title_jp: true,
       title_zh: true,
@@ -167,8 +170,19 @@ export class GameService {
 
     return {
       ...header,
+      h_id: await this.resolveHikarinagiId(id, header),
       content_limit,
     }
+  }
+
+  private async resolveHikarinagiId(
+    id: number,
+    game: { h_id?: number | null; b_id?: string | null } | null,
+  ) {
+    if (!game) return null
+    if (game.h_id != null || !game.b_id) return game.h_id ?? null
+
+    return await this.hikarinagiMappingService.resolveByBangumiId(id, game.b_id)
   }
 
   async getDetails(id: number, content_limit?: number) {

--- a/apps/backend/src/modules/hikarinagi/clients/hikarinagi.client.ts
+++ b/apps/backend/src/modules/hikarinagi/clients/hikarinagi.client.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@nestjs/common'
+import { HttpService } from '@nestjs/axios'
+import { firstValueFrom } from 'rxjs'
+import { ShionConfigService } from '../../../common/config/services/config.service'
+import { GalgameMappingEntry, HikarinagiEnvelope } from '../interfaces/galgame-mapping.interface'
+
+@Injectable()
+export class HikarinagiClient {
+  private static readonly TIMEOUT_MS = 10000
+
+  constructor(
+    private readonly httpService: HttpService,
+    private readonly configService: ShionConfigService,
+  ) {}
+
+  get enabled(): boolean {
+    return Boolean(this.baseUrl && this.secret)
+  }
+
+  async getMapping(page: number, pageSize: number) {
+    const envelope = await this.request<{ items: GalgameMappingEntry[] }>(
+      `/api/v3/internal/galgames/mapping?page=${page}&page_size=${pageSize}`,
+    )
+
+    return {
+      items: envelope.data?.items ?? [],
+      meta: envelope.meta ?? null,
+    }
+  }
+
+  async lookupByBangumiId(bangumiId: number) {
+    const envelope = await this.request<GalgameMappingEntry | null>(
+      `/api/v3/internal/galgames/lookup?bangumi_game_id=${bangumiId}`,
+    )
+
+    return envelope.data ?? null
+  }
+
+  private get baseUrl(): string {
+    return this.configService.get('hikarinagi.base_url').replace(/\/$/, '')
+  }
+
+  private get secret(): string {
+    return this.configService.get('partner.secret')
+  }
+
+  private async request<T>(path: string): Promise<HikarinagiEnvelope<T>> {
+    const response = await firstValueFrom(
+      this.httpService.get<HikarinagiEnvelope<T>>(`${this.baseUrl}${path}`, {
+        headers: { 'x-internal-secret': this.secret },
+        timeout: HikarinagiClient.TIMEOUT_MS,
+      }),
+    )
+
+    return response.data
+  }
+}

--- a/apps/backend/src/modules/hikarinagi/clients/hikarinagi.client.ts
+++ b/apps/backend/src/modules/hikarinagi/clients/hikarinagi.client.ts
@@ -2,7 +2,11 @@ import { Injectable } from '@nestjs/common'
 import { HttpService } from '@nestjs/axios'
 import { firstValueFrom } from 'rxjs'
 import { ShionConfigService } from '../../../common/config/services/config.service'
-import { GalgameMappingEntry, HikarinagiEnvelope } from '../interfaces/galgame-mapping.interface'
+import {
+  GalgameMappingEntry,
+  GalgameMappingMeta,
+  HikarinagiEnvelope,
+} from '../interfaces/galgame-mapping.interface'
 
 @Injectable()
 export class HikarinagiClient {
@@ -18,13 +22,14 @@ export class HikarinagiClient {
   }
 
   async getMapping(page: number, pageSize: number) {
-    const envelope = await this.request<{ items: GalgameMappingEntry[] }>(
-      `/api/v3/internal/galgames/mapping?page=${page}&page_size=${pageSize}`,
-    )
+    const envelope = await this.request<{
+      items: GalgameMappingEntry[]
+      meta?: GalgameMappingMeta
+    }>(`/api/v3/internal/galgames/mapping?page=${page}&page_size=${pageSize}`)
 
     return {
       items: envelope.data?.items ?? [],
-      meta: envelope.meta ?? null,
+      meta: envelope.data?.meta ?? null,
     }
   }
 

--- a/apps/backend/src/modules/hikarinagi/hikarinagi.module.ts
+++ b/apps/backend/src/modules/hikarinagi/hikarinagi.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common'
+import { HttpModule } from '@nestjs/axios'
+import { HikarinagiClient } from './clients/hikarinagi.client'
+import { HikarinagiMappingService } from './services/hikarinagi-mapping.service'
+import { HikarinagiMappingSyncTask } from './tasks/hikarinagi-mapping-sync.task'
+
+@Module({
+  imports: [HttpModule],
+  providers: [HikarinagiClient, HikarinagiMappingService, HikarinagiMappingSyncTask],
+  exports: [HikarinagiMappingService],
+})
+export class HikarinagiModule {}

--- a/apps/backend/src/modules/hikarinagi/interfaces/galgame-mapping.interface.ts
+++ b/apps/backend/src/modules/hikarinagi/interfaces/galgame-mapping.interface.ts
@@ -15,7 +15,6 @@ export interface GalgameMappingMeta {
 export interface HikarinagiEnvelope<T> {
   success: boolean
   data: T
-  meta?: GalgameMappingMeta
   request_id: string
   timestamp: string
 }

--- a/apps/backend/src/modules/hikarinagi/interfaces/galgame-mapping.interface.ts
+++ b/apps/backend/src/modules/hikarinagi/interfaces/galgame-mapping.interface.ts
@@ -1,0 +1,21 @@
+export interface GalgameMappingEntry {
+  id: number
+  vndb_id: number | null
+  bangumi_game_id: number | null
+}
+
+export interface GalgameMappingMeta {
+  page: number
+  page_size: number
+  total_items: number
+  item_count: number
+  total_pages: number
+}
+
+export interface HikarinagiEnvelope<T> {
+  success: boolean
+  data: T
+  meta?: GalgameMappingMeta
+  request_id: string
+  timestamp: string
+}

--- a/apps/backend/src/modules/hikarinagi/services/hikarinagi-mapping.service.spec.ts
+++ b/apps/backend/src/modules/hikarinagi/services/hikarinagi-mapping.service.spec.ts
@@ -1,0 +1,131 @@
+import { HikarinagiMappingService } from './hikarinagi-mapping.service'
+
+describe('HikarinagiMappingService', () => {
+  const meta = (page: number, totalPages: number) => ({
+    page,
+    page_size: 500,
+    total_items: 0,
+    item_count: 0,
+    total_pages: totalPages,
+  })
+
+  const createService = () => {
+    const prismaService = {
+      game: {
+        findMany: jest.fn().mockResolvedValue([]),
+        update: jest.fn().mockResolvedValue({}),
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+    }
+    const hikarinagiClient = {
+      enabled: true,
+      getMapping: jest.fn(),
+      lookupByBangumiId: jest.fn(),
+    }
+    const service = new HikarinagiMappingService(prismaService as never, hikarinagiClient as never)
+
+    return { service, prismaService, hikarinagiClient }
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('walks every page reported by meta', async () => {
+    const { service, hikarinagiClient } = createService()
+    hikarinagiClient.getMapping
+      .mockResolvedValueOnce({ items: [], meta: meta(1, 3) })
+      .mockResolvedValueOnce({ items: [], meta: meta(2, 3) })
+      .mockResolvedValueOnce({ items: [], meta: meta(3, 3) })
+
+    await service.syncMapping()
+
+    expect(hikarinagiClient.getMapping).toHaveBeenCalledTimes(3)
+    expect(hikarinagiClient.getMapping.mock.calls.map(c => c[0])).toEqual([1, 2, 3])
+  })
+
+  it('aborts without clearing when a page carries no meta', async () => {
+    const { service, prismaService, hikarinagiClient } = createService()
+    hikarinagiClient.getMapping.mockResolvedValueOnce({ items: [], meta: null })
+
+    const result = await service.syncMapping()
+
+    expect(result).toEqual({ synced: 0, cleared: 0 })
+    expect(prismaService.game.updateMany).not.toHaveBeenCalled()
+  })
+
+  it('matches games by bangumi id and stores the galgame id', async () => {
+    const { service, prismaService, hikarinagiClient } = createService()
+    hikarinagiClient.getMapping.mockResolvedValueOnce({
+      items: [{ id: 8001, vndb_id: 55317, bangumi_game_id: 218711 }],
+      meta: meta(1, 1),
+    })
+    prismaService.game.findMany.mockResolvedValueOnce([{ id: 1, b_id: '218711', h_id: null }])
+
+    const result = await service.syncMapping()
+
+    expect(prismaService.game.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { b_id: { in: ['218711'] } } }),
+    )
+    expect(prismaService.game.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: { h_id: 8001 },
+    })
+    expect(result.synced).toBe(1)
+  })
+
+  it('leaves an already correct h_id untouched', async () => {
+    const { service, prismaService, hikarinagiClient } = createService()
+    hikarinagiClient.getMapping.mockResolvedValueOnce({
+      items: [{ id: 8001, vndb_id: null, bangumi_game_id: 218711 }],
+      meta: meta(1, 1),
+    })
+    prismaService.game.findMany.mockResolvedValueOnce([{ id: 1, b_id: '218711', h_id: 8001 }])
+
+    await service.syncMapping()
+
+    expect(prismaService.game.update).not.toHaveBeenCalled()
+  })
+
+  it('clears h_id for games the walk did not see', async () => {
+    const { service, prismaService, hikarinagiClient } = createService()
+    hikarinagiClient.getMapping.mockResolvedValueOnce({
+      items: [{ id: 8001, vndb_id: null, bangumi_game_id: 218711 }],
+      meta: meta(1, 1),
+    })
+    prismaService.game.findMany.mockResolvedValueOnce([{ id: 1, b_id: '218711', h_id: 8001 }])
+
+    await service.syncMapping()
+
+    expect(prismaService.game.updateMany).toHaveBeenCalledWith({
+      where: { h_id: { not: null, notIn: [8001] } },
+      data: { h_id: null },
+    })
+  })
+
+  it('skips the sync entirely when the client is not configured', async () => {
+    const { service, prismaService, hikarinagiClient } = createService()
+    hikarinagiClient.enabled = false
+
+    const result = await service.syncMapping()
+
+    expect(result).toEqual({ synced: 0, cleared: 0 })
+    expect(hikarinagiClient.getMapping).not.toHaveBeenCalled()
+    expect(prismaService.game.updateMany).not.toHaveBeenCalled()
+  })
+
+  it('returns null and does not write when a lookup finds nothing', async () => {
+    const { service, prismaService, hikarinagiClient } = createService()
+    hikarinagiClient.lookupByBangumiId.mockResolvedValueOnce(null)
+
+    await expect(service.resolveByBangumiId(1, '218711')).resolves.toBeNull()
+    expect(prismaService.game.update).not.toHaveBeenCalled()
+  })
+
+  it('swallows a lookup failure so the caller is not broken', async () => {
+    const { service, hikarinagiClient } = createService()
+    hikarinagiClient.lookupByBangumiId.mockRejectedValueOnce(new Error('ECONNREFUSED'))
+
+    await expect(service.resolveByBangumiId(1, '218711')).resolves.toBeNull()
+  })
+})

--- a/apps/backend/src/modules/hikarinagi/services/hikarinagi-mapping.service.ts
+++ b/apps/backend/src/modules/hikarinagi/services/hikarinagi-mapping.service.ts
@@ -1,0 +1,114 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { PrismaService } from '../../../prisma.service'
+import { HikarinagiClient } from '../clients/hikarinagi.client'
+import { GalgameMappingEntry } from '../interfaces/galgame-mapping.interface'
+
+@Injectable()
+export class HikarinagiMappingService {
+  private static readonly PAGE_SIZE = 500
+
+  private readonly logger = new Logger(HikarinagiMappingService.name)
+
+  constructor(
+    private readonly prismaService: PrismaService,
+    private readonly hikarinagiClient: HikarinagiClient,
+  ) {}
+
+  async syncMapping(): Promise<{ synced: number; cleared: number }> {
+    if (!this.hikarinagiClient.enabled) {
+      this.logger.warn('hikarinagi internal api not configured, skip mapping sync')
+      return { synced: 0, cleared: 0 }
+    }
+
+    const seen = new Set<number>()
+    let synced = 0
+    let page = 1
+    let totalPages = 1
+
+    while (page <= totalPages) {
+      const { items, meta } = await this.hikarinagiClient.getMapping(
+        page,
+        HikarinagiMappingService.PAGE_SIZE,
+      )
+      totalPages = meta?.total_pages ?? page
+
+      synced += await this.applyPage(items, seen)
+      page += 1
+    }
+
+    const cleared = await this.clearStale(seen)
+    this.logger.log(`hikarinagi mapping synced: ${synced} matched, ${cleared} cleared`)
+
+    return { synced, cleared }
+  }
+
+  async resolveByBangumiId(gameId: number, bangumiId: string): Promise<number | null> {
+    if (!this.hikarinagiClient.enabled) return null
+
+    const numericBangumiId = this.toNumericId(bangumiId)
+    if (numericBangumiId === null) return null
+
+    try {
+      const entry = await this.hikarinagiClient.lookupByBangumiId(numericBangumiId)
+      if (!entry) return null
+
+      await this.prismaService.game.update({
+        where: { id: gameId },
+        data: { h_id: entry.id },
+      })
+
+      return entry.id
+    } catch (error) {
+      this.logger.warn(
+        `hikarinagi lookup failed for game ${gameId} (bgm ${bangumiId}): ${(error as Error).message}`,
+      )
+
+      return null
+    }
+  }
+
+  private async applyPage(items: GalgameMappingEntry[], seen: Set<number>): Promise<number> {
+    const byBangumiId = new Map<string, number>()
+    for (const item of items) {
+      if (item.bangumi_game_id !== null) byBangumiId.set(String(item.bangumi_game_id), item.id)
+    }
+    if (byBangumiId.size === 0) return 0
+
+    const games = await this.prismaService.game.findMany({
+      where: { b_id: { in: [...byBangumiId.keys()] } },
+      select: { id: true, b_id: true, h_id: true },
+    })
+
+    let matched = 0
+    for (const game of games) {
+      const galgameId = byBangumiId.get(game.b_id!)
+      if (galgameId === undefined) continue
+
+      seen.add(galgameId)
+      matched += 1
+      if (game.h_id === galgameId) continue
+
+      await this.prismaService.game.update({
+        where: { id: game.id },
+        data: { h_id: galgameId },
+      })
+    }
+
+    return matched
+  }
+
+  private async clearStale(seen: Set<number>): Promise<number> {
+    const result = await this.prismaService.game.updateMany({
+      where: { h_id: { not: null, notIn: [...seen] } },
+      data: { h_id: null },
+    })
+
+    return result.count
+  }
+
+  private toNumericId(value: string): number | null {
+    const parsed = Number(value)
+
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+  }
+}

--- a/apps/backend/src/modules/hikarinagi/services/hikarinagi-mapping.service.ts
+++ b/apps/backend/src/modules/hikarinagi/services/hikarinagi-mapping.service.ts
@@ -23,14 +23,18 @@ export class HikarinagiMappingService {
     const seen = new Set<number>()
     let synced = 0
     let page = 1
-    let totalPages = 1
+    let totalPages: number | null = null
 
-    while (page <= totalPages) {
+    while (totalPages === null || page <= totalPages) {
       const { items, meta } = await this.hikarinagiClient.getMapping(
         page,
         HikarinagiMappingService.PAGE_SIZE,
       )
-      totalPages = meta?.total_pages ?? page
+      if (!meta) {
+        this.logger.warn('hikarinagi mapping page missing meta, aborting before stale cleanup')
+        return { synced, cleared: 0 }
+      }
+      totalPages = meta.total_pages
 
       synced += await this.applyPage(items, seen)
       page += 1

--- a/apps/backend/src/modules/hikarinagi/tasks/hikarinagi-mapping-sync.task.ts
+++ b/apps/backend/src/modules/hikarinagi/tasks/hikarinagi-mapping-sync.task.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common'
+import { Cron, CronExpression } from '@nestjs/schedule'
+import { HikarinagiMappingService } from '../services/hikarinagi-mapping.service'
+
+@Injectable()
+export class HikarinagiMappingSyncTask {
+  constructor(private readonly hikarinagiMappingService: HikarinagiMappingService) {}
+
+  @Cron(CronExpression.EVERY_6_HOURS)
+  async handle() {
+    await this.hikarinagiMappingService.syncMapping()
+  }
+}

--- a/apps/backend/src/modules/partner/controllers/partner-download.controller.ts
+++ b/apps/backend/src/modules/partner/controllers/partner-download.controller.ts
@@ -17,8 +17,8 @@ export class PartnerDownloadController {
   }
 
   @Get()
-  async getByVndbId(@Query() query: PartnerVndbQueryReqDto) {
-    return await this.partnerDownloadService.getByVndbId(query.v_id)
+  async getByExternalId(@Query() query: PartnerVndbQueryReqDto) {
+    return await this.partnerDownloadService.getByExternalId(query.v_id, query.b_id)
   }
 
   @Get('file/:fileId/link')

--- a/apps/backend/src/modules/partner/dto/req/partner-download.req.dto.ts
+++ b/apps/backend/src/modules/partner/dto/req/partner-download.req.dto.ts
@@ -1,4 +1,4 @@
-import { IsNumber, IsOptional, IsString, Min, Max, MaxLength } from 'class-validator'
+import { IsNumber, IsOptional, IsString, Min, Max, MaxLength, ValidateIf } from 'class-validator'
 import { Type } from 'class-transformer'
 import { ivm } from '../../../../common/validation/i18n'
 
@@ -24,7 +24,13 @@ export class PartnerSummaryQueryReqDto {
 }
 
 export class PartnerVndbQueryReqDto {
+  @ValidateIf(o => !o.b_id)
   @IsString({ message: ivm('validation.common.IS_STRING', { property: 'v_id' }) })
   @MaxLength(32)
-  v_id: string
+  v_id?: string
+
+  @IsString({ message: ivm('validation.common.IS_STRING', { property: 'b_id' }) })
+  @IsOptional()
+  @MaxLength(32)
+  b_id?: string
 }

--- a/apps/backend/src/modules/partner/dto/res/partner-download.res.dto.ts
+++ b/apps/backend/src/modules/partner/dto/res/partner-download.res.dto.ts
@@ -1,7 +1,9 @@
 import { GamePlatform } from '../../../game/interfaces/game.interface'
 
 export class PartnerDownloadSummaryResDto {
-  v_id: string
+  game_id: number
+  v_id: string | null
+  b_id: string | null
   resource_count: number
   file_count: number
   total_size: string

--- a/apps/backend/src/modules/partner/services/partner-download.service.ts
+++ b/apps/backend/src/modules/partner/services/partner-download.service.ts
@@ -30,21 +30,30 @@ export class PartnerDownloadService {
 
     const [{ count }] = await this.prismaService.$queryRaw<[{ count: bigint }]>`
       SELECT COUNT(*)::bigint AS count FROM (
-        SELECT g.v_id
+        SELECT g.id
         FROM games g
         JOIN game_download_resources r ON r.game_id = g.id AND r.status = 1
         JOIN game_download_resource_files f ON f.game_download_resource_id = r.id
           AND f.file_status = 3
           AND (f.file_check_status NOT IN (5, 6) OR f.is_virus_false_positive = true)
-        WHERE g.v_id IS NOT NULL AND g.v_id <> ''
-        GROUP BY g.v_id
+        WHERE (g.v_id IS NOT NULL AND g.v_id <> '') OR (g.b_id IS NOT NULL AND g.b_id <> '')
+        GROUP BY g.id
       ) grouped
     `
 
     const rows = await this.prismaService.$queryRaw<
-      { v_id: string; resource_count: bigint; file_count: bigint; total_size: bigint }[]
+      {
+        game_id: number
+        v_id: string | null
+        b_id: string | null
+        resource_count: bigint
+        file_count: bigint
+        total_size: bigint
+      }[]
     >`
-      SELECT g.v_id,
+      SELECT g.id AS game_id,
+             g.v_id,
+             g.b_id,
              COUNT(DISTINCT r.id)::bigint AS resource_count,
              COUNT(f.id)::bigint AS file_count,
              COALESCE(SUM(f.file_size), 0)::bigint AS total_size
@@ -53,9 +62,9 @@ export class PartnerDownloadService {
       JOIN game_download_resource_files f ON f.game_download_resource_id = r.id
         AND f.file_status = 3
         AND (f.file_check_status NOT IN (5, 6) OR f.is_virus_false_positive = true)
-      WHERE g.v_id IS NOT NULL AND g.v_id <> ''
-      GROUP BY g.v_id
-      ORDER BY g.v_id
+      WHERE (g.v_id IS NOT NULL AND g.v_id <> '') OR (g.b_id IS NOT NULL AND g.b_id <> '')
+      GROUP BY g.id, g.v_id, g.b_id
+      ORDER BY g.id
       LIMIT ${pageSize} OFFSET ${(page - 1) * pageSize}
     `
 
@@ -63,7 +72,9 @@ export class PartnerDownloadService {
 
     return {
       items: rows.map(row => ({
+        game_id: row.game_id,
         v_id: row.v_id,
+        b_id: row.b_id,
         resource_count: Number(row.resource_count),
         file_count: Number(row.file_count),
         total_size: row.total_size.toString(),
@@ -78,9 +89,13 @@ export class PartnerDownloadService {
     }
   }
 
-  async getByVndbId(vId: string): Promise<PartnerDownloadResourceResDto[]> {
+  async getByExternalId(vId?: string, bId?: string): Promise<PartnerDownloadResourceResDto[]> {
+    const or: Prisma.GameWhereInput[] = []
+    if (vId) or.push({ v_id: vId })
+    if (bId) or.push({ b_id: bId })
+
     const games = await this.prismaService.game.findMany({
-      where: { v_id: vId },
+      where: { OR: or },
       select: {
         id: true,
         download_resources: {

--- a/apps/frontend/components/game/actions/Download.tsx
+++ b/apps/frontend/components/game/actions/Download.tsx
@@ -9,9 +9,16 @@ interface DownloadProps {
   game_title?: string
   bangumi_id?: string
   vndb_id?: string
+  hikarinagi_id?: number
 }
 
-export const Download = ({ game_id, game_title, bangumi_id, vndb_id }: DownloadProps) => {
+export const Download = ({
+  game_id,
+  game_title,
+  bangumi_id,
+  vndb_id,
+  hikarinagi_id,
+}: DownloadProps) => {
   const [downloadOpen, setDownloadOpen] = useState(false)
   const [downloadBtnLoading, setDownloadBtnLoading] = useState(false)
   const t = useTranslations('Components.Game.Actions')
@@ -30,6 +37,7 @@ export const Download = ({ game_id, game_title, bangumi_id, vndb_id }: DownloadP
         game_title={game_title}
         bangumi_id={bangumi_id}
         vndb_id={vndb_id}
+        hikarinagi_id={hikarinagi_id}
         open={downloadOpen}
         onOpenChange={setDownloadOpen}
         onLoadingChange={setDownloadBtnLoading}

--- a/apps/frontend/components/game/actions/GameActions.tsx
+++ b/apps/frontend/components/game/actions/GameActions.tsx
@@ -38,6 +38,7 @@ export const GameActions = ({ game, is_favorite }: GameActionsProps) => {
                 game_title={title}
                 bangumi_id={game.b_id}
                 vndb_id={game.v_id}
+                hikarinagi_id={game.h_id}
               />
               <Patch game_id={game.id} v_id={game.v_id!} />
               <Upload game_id={game.id} />

--- a/apps/frontend/components/game/download/GameDownload.tsx
+++ b/apps/frontend/components/game/download/GameDownload.tsx
@@ -12,6 +12,7 @@ interface GameDownloadProps {
   game_title?: string
   bangumi_id?: string
   vndb_id?: string
+  hikarinagi_id?: number
   open: boolean
   onLoadingChange: (loading: boolean) => void
   onOpenChange: (open: boolean) => void
@@ -22,6 +23,7 @@ export const GameDownload = ({
   game_title,
   bangumi_id,
   vndb_id,
+  hikarinagi_id,
   open,
   onLoadingChange,
   onOpenChange,
@@ -88,7 +90,7 @@ export const GameDownload = ({
     setDownloadResources(prev => prev.filter(resource => resource.id !== id))
 
   return (
-    <GameDownloadMetaContext.Provider value={{ game_title, bangumi_id, vndb_id }}>
+    <GameDownloadMetaContext.Provider value={{ game_title, bangumi_id, vndb_id, hikarinagi_id }}>
       <Modal
         title={t('title')}
         open={open && isReady}

--- a/apps/frontend/components/game/download/GameDownloadContext.tsx
+++ b/apps/frontend/components/game/download/GameDownloadContext.tsx
@@ -4,6 +4,7 @@ interface GameDownloadMetaContextValue {
   game_title?: string
   bangumi_id?: string
   vndb_id?: string
+  hikarinagi_id?: number
 }
 
 export const GameDownloadMetaContext = createContext<GameDownloadMetaContextValue>({})

--- a/apps/frontend/components/game/download/helpers/lunabox.ts
+++ b/apps/frontend/components/game/download/helpers/lunabox.ts
@@ -8,7 +8,7 @@ interface LunaBoxParams {
   checksum: string
   expiresAt: number
   title?: string
-  bangumiId?: string
+  hikarinagiId?: number
 }
 
 export const buildLunaBoxUrl = ({
@@ -19,7 +19,7 @@ export const buildLunaBoxUrl = ({
   checksum,
   expiresAt,
   title,
-  bangumiId,
+  hikarinagiId,
 }: LunaBoxParams): string => {
   const params = new URLSearchParams({
     url,
@@ -33,10 +33,10 @@ export const buildLunaBoxUrl = ({
   })
 
   if (title) params.set('title', title)
-  if (bangumiId) {
-    params.set('source', 'bangumi')
-    params.set('meta_source', 'bangumi')
-    params.set('meta_id', bangumiId)
+  if (hikarinagiId) {
+    params.set('source', 'hikarinagi')
+    params.set('meta_source', 'hikarinagi')
+    params.set('meta_id', String(hikarinagiId))
   }
 
   return `lunabox://install?${params.toString()}`

--- a/apps/frontend/components/game/download/helpers/reina.ts
+++ b/apps/frontend/components/game/download/helpers/reina.ts
@@ -11,6 +11,7 @@ interface ReinaParams {
   title: string
   bangumiId: string
   vndbId?: string
+  hikarinagiId?: number
 }
 
 const ensureVndbPrefix = (vndbId: string) => (vndbId.startsWith('v') ? vndbId : `v${vndbId}`)
@@ -26,6 +27,7 @@ export const buildReinaUrl = ({
   title,
   bangumiId,
   vndbId,
+  hikarinagiId,
 }: ReinaParams): string => {
   const params = new URLSearchParams({
     v: '1',
@@ -43,6 +45,7 @@ export const buildReinaUrl = ({
   })
 
   if (vndbId) params.set('vndb_id', ensureVndbPrefix(vndbId))
+  if (hikarinagiId) params.set('hikarinagi_id', String(hikarinagiId))
 
   return `reinamanager://install?${params.toString()}`
 }

--- a/apps/frontend/components/game/download/ways/DownloadWays.tsx
+++ b/apps/frontend/components/game/download/ways/DownloadWays.tsx
@@ -40,7 +40,7 @@ export const DownloadWays = ({
   const { getSettings } = useAria2Store()
   const { protocol, host, port, path, auth_secret, downloadPath } = getSettings()
   const router = useRouter()
-  const { game_title, bangumi_id, vndb_id } = useGameDownloadMeta()
+  const { game_title, bangumi_id, vndb_id, hikarinagi_id } = useGameDownloadMeta()
   const showLunaBox = useLunaBoxStore(state => state.showLunaBox)
   const showReina = useReinaStore(state => state.showReina)
   const [pending, setPending] = useState<PendingWay | null>(null)
@@ -131,7 +131,7 @@ export const DownloadWays = ({
       checksum: file.file_hash,
       expiresAt: downloadLinkExpiresAt.current,
       title: game_title,
-      bangumiId: bangumi_id,
+      hikarinagiId: hikarinagi_id,
     })
     openProtocolUrl(lunaBoxUrl)
     sileo.success({ title: t('downloadStarted') })
@@ -154,6 +154,7 @@ export const DownloadWays = ({
       title: game_title ?? file.file_name,
       bangumiId: bangumi_id,
       vndbId: vndb_id,
+      hikarinagiId: hikarinagi_id,
     })
     openProtocolUrl(reinaUrl)
     sileo.success({ title: t('downloadStarted') })

--- a/apps/frontend/interfaces/game/game.interface.ts
+++ b/apps/frontend/interfaces/game/game.interface.ts
@@ -212,6 +212,7 @@ export interface GameData {
 
   b_id?: string
   v_id?: string
+  h_id?: number
 
   id: number
   title_jp: string
@@ -244,6 +245,7 @@ export interface GameHeader extends Pick<
   GameData,
   | 'v_id'
   | 'b_id'
+  | 'h_id'
   | 'id'
   | 'title_jp'
   | 'title_zh'


### PR DESCRIPTION
Add Game.h_id plus a hikarinagi module that resolves it from the sibling service: read it when stored, look it up over the internal API and persist when not, with a 6-hourly full sync as the backstop.

Match on b_id rather than v_id — hikarinagi keys galgames by bangumi id (bangumi_game_id is unique, vndb_id is not).

The partner summary now groups by game and carries both external ids so the consumer can match either way, and the resource query accepts both.

LunaBox now receives source/meta_source=hikarinagi with the galgame id as meta_id; ReinaManager gets it as the optional hikarinagi_id.